### PR TITLE
FTBFS: dpkg-gencontrol cannot handle an arch-specific depends/recommends when package is arch:all

### DIFF
--- a/precise/primus/debian/control
+++ b/precise/primus/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/amonakov/primus
 Vcs-Git: git://github.com/amonakov/primus.git
 
 Package: primus
-Architecture: all
+Architecture: i386 amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, bumblebee,
  primus-libs (= ${binary:Version})
 Recommends: primus-libs-ia32 [amd64]

--- a/quantal/primus/debian/control
+++ b/quantal/primus/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/amonakov/primus
 Vcs-Git: git://github.com/amonakov/primus.git
 
 Package: primus
-Architecture: all
+Architecture: i386 amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, bumblebee,
  primus-libs (= ${binary:Version})
 Recommends: primus-libs-ia32 [amd64]

--- a/raring/primus/debian/control
+++ b/raring/primus/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/amonakov/primus
 Vcs-Git: git://github.com/amonakov/primus.git
 
 Package: primus
-Architecture: all
+Architecture: i386 amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}, bumblebee,
  primus-libs (= ${binary:Version})
 Recommends: primus-libs-ia32 [amd64]


### PR DESCRIPTION
...d by dpkg-gencontrol ("the Recommends field contains an arch-specific dependency but the pacckage is architecture all"). Fixes issue #11.
