### PR TITLE
Generate aliases in bumblebee.conf on Ubuntu

### DIFF
--- a/precise/bumblebee/debian/bumblebee.postinst
+++ b/precise/bumblebee/debian/bumblebee.postinst
@@ -36,6 +36,10 @@ case "$1" in
             echo "Deleting old /etc/bumblebee/xorg.conf.d/busid.conf"
             rm /etc/bumblebee/xorg.conf.d/busid.conf
         fi
+        # On Ubuntu modprobe remove line is not present
+        echo "Adding modprobe remove line to /etc/modprobe.d/bumblebee.conf"
+        echo "# Workaround to make sure nvidia-uvm is removed as well" >> /usr/share/bumblebee/default-conf/bumblebee.conf
+        echo "remove nvidia rmmod nvidia-uvm nvidia" >> /usr/share/bumblebee/default-conf/bumblebee.conf
     fi
 
     # Do not treat /etc/modprobe.d/bumblebee-nvidia.conf as a conffile

--- a/trusty/bumblebee/debian/bumblebee.postinst
+++ b/trusty/bumblebee/debian/bumblebee.postinst
@@ -51,6 +51,10 @@ case "$1" in
             echo "Deleting old /etc/bumblebee/xorg.conf.d/busid.conf"
             rm /etc/bumblebee/xorg.conf.d/busid.conf
         fi
+        # On Ubuntu modprobe remove line is not present
+        echo "Adding modprobe remove line to /etc/modprobe.d/bumblebee.conf"
+        echo "# Workaround to make sure nvidia-uvm is removed as well" >> /usr/share/bumblebee/default-conf/bumblebee.conf
+        echo "remove nvidia rmmod nvidia-uvm nvidia" >> /usr/share/bumblebee/default-conf/bumblebee.conf
     fi
 
     # Do not treat /etc/modprobe.d/bumblebee-nvidia.conf as a conffile

--- a/vivid/bumblebee/debian/bumblebee.postinst
+++ b/vivid/bumblebee/debian/bumblebee.postinst
@@ -51,6 +51,10 @@ case "$1" in
             echo "Deleting old /etc/bumblebee/xorg.conf.d/busid.conf"
             rm /etc/bumblebee/xorg.conf.d/busid.conf
         fi
+        # On Ubuntu modprobe remove line is not present
+        echo "Adding modprobe remove line to /etc/modprobe.d/bumblebee.conf"
+        echo "# Workaround to make sure nvidia-uvm is removed as well" >> /usr/share/bumblebee/default-conf/bumblebee.conf
+        echo "remove nvidia rmmod nvidia-uvm nvidia" >> /usr/share/bumblebee/default-conf/bumblebee.conf
     fi
 
     # Do not treat /etc/modprobe.d/bumblebee-nvidia.conf as a conffile

--- a/wily/bumblebee/debian/bumblebee.postinst
+++ b/wily/bumblebee/debian/bumblebee.postinst
@@ -51,6 +51,10 @@ case "$1" in
             echo "Deleting old /etc/bumblebee/xorg.conf.d/busid.conf"
             rm /etc/bumblebee/xorg.conf.d/busid.conf
         fi
+        # On Ubuntu modprobe remove line is not present
+        echo "Adding modprobe remove line to /etc/modprobe.d/bumblebee.conf"
+        echo "# Workaround to make sure nvidia-uvm is removed as well" >> /usr/share/bumblebee/default-conf/bumblebee.conf
+        echo "remove nvidia rmmod nvidia-uvm nvidia" >> /usr/share/bumblebee/default-conf/bumblebee.conf
     fi
 
     # Do not treat /etc/modprobe.d/bumblebee-nvidia.conf as a conffile


### PR DESCRIPTION
On Ubuntu, the Nvidia driver packages at the moment do not define
a remove rule for modprobe, which causes bumblebee to fail when
the patch to use modprobe -r is applied.
Add aliases and remove rules to bumblebee.conf during postinst phase
if building on Ubuntu as a workaround.