### PR TITLE
Default module name and new drivers

### DIFF
--- a/precise/bumblebee/debian/changelog
+++ b/precise/bumblebee/debian/changelog
@@ -1,6 +1,7 @@
 bumblebee (3.2.1-95~preciseppa1) UNRELEASED; urgency=medium
 
   * Set Ubuntu default kernel driver to nvidia
+  * Update bumblebee-nvidia dependency to new drivers
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:02:07 +0100
 

--- a/precise/bumblebee/debian/changelog
+++ b/precise/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-95~preciseppa1) UNRELEASED; urgency=medium
+
+  * Set Ubuntu default kernel driver to nvidia
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:02:07 +0100
+
 bumblebee (3.2.1-94~preciseppa1) precise; urgency=medium
 
   * Sync debian/copyright with Debian 3.1.2-12

--- a/precise/bumblebee/debian/control
+++ b/precise/bumblebee/debian/control
@@ -73,7 +73,10 @@ Depends:
  nvidia-346 | nvidia-346-updates | nvidia-experimental-346 |
  nvidia-349 | nvidia-349-updates | nvidia-experimental-349 |
  nvidia-352 | nvidia-352-updates | nvidia-experimental-352 |
- nvidia-355 | nvidia-355-updates | nvidia-experimental-355
+ nvidia-355 | nvidia-355-updates | nvidia-experimental-355 |
+ nvidia-358 | nvidia-358-updates | nvidia-experimental-358 |
+ nvidia-361 | nvidia-361-updates | nvidia-experimental-361 |
+ nvidia-364 | nvidia-364-updates | nvidia-experimental-364
 Description: NVIDIA Optimus support using the proprietary NVIDIA driver
  This metapackage ensures that the proprietary NVIDIA driver is installed in a
  way such that 3D acceleration does not break. It does so by configuring the

--- a/precise/bumblebee/debian/rules
+++ b/precise/bumblebee/debian/rules
@@ -17,7 +17,7 @@ MAINTSCRIPTS_GENERATED	+= debian/bumblebee-nvidia.postrm
 
 configure-for-Ubuntu:
 	dh_auto_configure -- \
-		CONF_DRIVER_MODULE_NVIDIA=nvidia-current \
+		CONF_DRIVER_MODULE_NVIDIA=nvidia \
 		CONF_LDPATH_NVIDIA=/usr/lib/nvidia-current:/usr/lib32/nvidia-current \
 		CONF_MODPATH_NVIDIA=/usr/lib/nvidia-current/xorg,/usr/lib/xorg/modules \
 		CONF_PRIMUS_LD_PATH=/usr/lib/x86_64-linux-gnu/primus:/usr/lib/i386-linux-gnu/primus

--- a/trusty/bumblebee/debian/changelog
+++ b/trusty/bumblebee/debian/changelog
@@ -1,6 +1,7 @@
 bumblebee (3.2.1-95~trustyppa1) UNRELEASED; urgency=medium
 
   * Set Ubuntu default kernel driver to nvidia
+  * Update bumblebee-nvidia dependency to new drivers
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:02:47 +0100
 

--- a/trusty/bumblebee/debian/changelog
+++ b/trusty/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-95~trustyppa1) UNRELEASED; urgency=medium
+
+  * Set Ubuntu default kernel driver to nvidia
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:02:47 +0100
+
 bumblebee (3.2.1-94~trustyppa1) trusty; urgency=medium
 
   * Sync debian/copyright with Debian 3.1.2-12

--- a/trusty/bumblebee/debian/control
+++ b/trusty/bumblebee/debian/control
@@ -74,7 +74,10 @@ Depends:
  nvidia-346 | nvidia-346-updates | nvidia-experimental-346 |
  nvidia-349 | nvidia-349-updates | nvidia-experimental-349 |
  nvidia-352 | nvidia-352-updates | nvidia-experimental-352 |
- nvidia-355 | nvidia-355-updates | nvidia-experimental-355
+ nvidia-355 | nvidia-355-updates | nvidia-experimental-355 |
+ nvidia-358 | nvidia-358-updates | nvidia-experimental-358 |
+ nvidia-361 | nvidia-361-updates | nvidia-experimental-361 |
+ nvidia-364 | nvidia-364-updates | nvidia-experimental-364
 Description: NVIDIA Optimus support using the proprietary NVIDIA driver
  This metapackage ensures that the proprietary NVIDIA driver is installed in a
  way such that 3D acceleration does not break. It does so by configuring the

--- a/trusty/bumblebee/debian/rules
+++ b/trusty/bumblebee/debian/rules
@@ -17,7 +17,7 @@ MAINTSCRIPTS_GENERATED	+= debian/bumblebee-nvidia.postrm
 
 configure-for-Ubuntu:
 	dh_auto_configure -- \
-		CONF_DRIVER_MODULE_NVIDIA=nvidia-current \
+		CONF_DRIVER_MODULE_NVIDIA=nvidia \
 		CONF_LDPATH_NVIDIA=/usr/lib/nvidia-current:/usr/lib32/nvidia-current \
 		CONF_MODPATH_NVIDIA=/usr/lib/nvidia-current/xorg,/usr/lib/xorg/modules \
 		CONF_PRIMUS_LD_PATH=/usr/lib/x86_64-linux-gnu/primus:/usr/lib/i386-linux-gnu/primus

--- a/vivid/bumblebee/debian/changelog
+++ b/vivid/bumblebee/debian/changelog
@@ -1,6 +1,7 @@
 bumblebee (3.2.1-95~vividppa1) UNRELEASED; urgency=medium
 
   * Set Ubuntu default kernel driver to nvidia
+  * Update bumblebee-nvidia dependency to new drivers
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:02:58 +0100
 

--- a/vivid/bumblebee/debian/changelog
+++ b/vivid/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-95~vividppa1) UNRELEASED; urgency=medium
+
+  * Set Ubuntu default kernel driver to nvidia
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:02:58 +0100
+
 bumblebee (3.2.1-94~vividppa1) vivid; urgency=medium
 
   * Sync debian/copyright with Debian 3.1.2-12

--- a/vivid/bumblebee/debian/control
+++ b/vivid/bumblebee/debian/control
@@ -74,7 +74,10 @@ Depends:
  nvidia-346 | nvidia-346-updates | nvidia-experimental-346 |
  nvidia-349 | nvidia-349-updates | nvidia-experimental-349 |
  nvidia-352 | nvidia-352-updates | nvidia-experimental-352 |
- nvidia-355 | nvidia-355-updates | nvidia-experimental-355
+ nvidia-355 | nvidia-355-updates | nvidia-experimental-355 |
+ nvidia-358 | nvidia-358-updates | nvidia-experimental-358 |
+ nvidia-361 | nvidia-361-updates | nvidia-experimental-361 |
+ nvidia-364 | nvidia-364-updates | nvidia-experimental-364
 Description: NVIDIA Optimus support using the proprietary NVIDIA driver
  This metapackage ensures that the proprietary NVIDIA driver is installed in a
  way such that 3D acceleration does not break. It does so by configuring the

--- a/vivid/bumblebee/debian/rules
+++ b/vivid/bumblebee/debian/rules
@@ -17,7 +17,7 @@ MAINTSCRIPTS_GENERATED	+= debian/bumblebee-nvidia.postrm
 
 configure-for-Ubuntu:
 	dh_auto_configure -- \
-		CONF_DRIVER_MODULE_NVIDIA=nvidia-current \
+		CONF_DRIVER_MODULE_NVIDIA=nvidia \
 		CONF_LDPATH_NVIDIA=/usr/lib/nvidia-current:/usr/lib32/nvidia-current \
 		CONF_MODPATH_NVIDIA=/usr/lib/nvidia-current/xorg,/usr/lib/xorg/modules \
 		CONF_PRIMUS_LD_PATH=/usr/lib/x86_64-linux-gnu/primus:/usr/lib/i386-linux-gnu/primus

--- a/wily/bumblebee/debian/changelog
+++ b/wily/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-95~wilyppa1) UNRELEASED; urgency=medium
+
+  * Set Ubuntu default kernel driver to nvidia
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:03:08 +0100
+
 bumblebee (3.2.1-94~wilyppa1) wily; urgency=medium
 
   * Sync debian/copyright with Debian 3.1.2-12

--- a/wily/bumblebee/debian/changelog
+++ b/wily/bumblebee/debian/changelog
@@ -1,6 +1,7 @@
 bumblebee (3.2.1-95~wilyppa1) UNRELEASED; urgency=medium
 
   * Set Ubuntu default kernel driver to nvidia
+  * Update bumblebee-nvidia dependency to new drivers
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:03:08 +0100
 

--- a/wily/bumblebee/debian/control
+++ b/wily/bumblebee/debian/control
@@ -74,7 +74,10 @@ Depends:
  nvidia-346 | nvidia-346-updates | nvidia-experimental-346 |
  nvidia-349 | nvidia-349-updates | nvidia-experimental-349 |
  nvidia-352 | nvidia-352-updates | nvidia-experimental-352 |
- nvidia-355 | nvidia-355-updates | nvidia-experimental-355
+ nvidia-355 | nvidia-355-updates | nvidia-experimental-355 |
+ nvidia-358 | nvidia-358-updates | nvidia-experimental-358 |
+ nvidia-361 | nvidia-361-updates | nvidia-experimental-361 |
+ nvidia-364 | nvidia-364-updates | nvidia-experimental-364
 Description: NVIDIA Optimus support using the proprietary NVIDIA driver
  This metapackage ensures that the proprietary NVIDIA driver is installed in a
  way such that 3D acceleration does not break. It does so by configuring the

--- a/wily/bumblebee/debian/rules
+++ b/wily/bumblebee/debian/rules
@@ -17,7 +17,7 @@ MAINTSCRIPTS_GENERATED	+= debian/bumblebee-nvidia.postrm
 
 configure-for-Ubuntu:
 	dh_auto_configure -- \
-		CONF_DRIVER_MODULE_NVIDIA=nvidia-current \
+		CONF_DRIVER_MODULE_NVIDIA=nvidia \
 		CONF_LDPATH_NVIDIA=/usr/lib/nvidia-current:/usr/lib32/nvidia-current \
 		CONF_MODPATH_NVIDIA=/usr/lib/nvidia-current/xorg,/usr/lib/xorg/modules \
 		CONF_PRIMUS_LD_PATH=/usr/lib/x86_64-linux-gnu/primus:/usr/lib/i386-linux-gnu/primus

--- a/xenial/bumblebee/debian/changelog
+++ b/xenial/bumblebee/debian/changelog
@@ -1,6 +1,7 @@
 bumblebee (3.2.1-95~xenialppa1) UNRELEASED; urgency=medium
 
   * Set Ubuntu default kernel driver to nvidia
+  * Update bumblebee-nvidia dependency to new drivers
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:04:03 +0100
 

--- a/xenial/bumblebee/debian/changelog
+++ b/xenial/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-95~xenialppa1) UNRELEASED; urgency=medium
+
+  * Set Ubuntu default kernel driver to nvidia
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Mon, 16 May 2016 23:04:03 +0100
+
 bumblebee (3.2.1-94~xenialppa1) xenial; urgency=medium
 
   * Initial release for xenial.

--- a/xenial/bumblebee/debian/control
+++ b/xenial/bumblebee/debian/control
@@ -75,7 +75,10 @@ Depends:
  nvidia-346 | nvidia-346-updates | nvidia-experimental-346 |
  nvidia-349 | nvidia-349-updates | nvidia-experimental-349 |
  nvidia-352 | nvidia-352-updates | nvidia-experimental-352 |
- nvidia-355 | nvidia-355-updates | nvidia-experimental-355
+ nvidia-355 | nvidia-355-updates | nvidia-experimental-355 |
+ nvidia-358 | nvidia-358-updates | nvidia-experimental-358 |
+ nvidia-361 | nvidia-361-updates | nvidia-experimental-361 |
+ nvidia-364 | nvidia-364-updates | nvidia-experimental-364
 Description: NVIDIA Optimus support using the proprietary NVIDIA driver
  This metapackage ensures that the proprietary NVIDIA driver is installed in a
  way such that 3D acceleration does not break. It does so by configuring the

--- a/xenial/bumblebee/debian/rules
+++ b/xenial/bumblebee/debian/rules
@@ -17,7 +17,7 @@ MAINTSCRIPTS_GENERATED	+= debian/bumblebee-nvidia.postrm
 
 configure-for-Ubuntu:
 	dh_auto_configure -- \
-		CONF_DRIVER_MODULE_NVIDIA=nvidia-current \
+		CONF_DRIVER_MODULE_NVIDIA=nvidia \
 		CONF_LDPATH_NVIDIA=/usr/lib/nvidia-current:/usr/lib32/nvidia-current \
 		CONF_MODPATH_NVIDIA=/usr/lib/nvidia-current/xorg,/usr/lib/xorg/modules \
 		CONF_PRIMUS_LD_PATH=/usr/lib/x86_64-linux-gnu/primus:/usr/lib/i386-linux-gnu/primus \


### PR DESCRIPTION
It looks like all versions of the drivers ship a modprobe.conf file which aliases the kernel module to "nvidia", so it's the safest default value. Also update the bumblebee-nvidia drivers dependency list.

@Vincent-C @ArchangeGabriel - again if no objections, I'll merge tomorrow.