### PR TITLE
backport libkmod patch and get rid of modprobe hack

### DIFF
--- a/trusty/bumblebee/debian/changelog
+++ b/trusty/bumblebee/debian/changelog
@@ -1,11 +1,11 @@
-bumblebee (3.2.1-96~trustyppa1) UNRELEASED; urgency=medium
+bumblebee (3.2.1-96~trustyppa1) trusty; urgency=medium
 
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
   * Remove Ubuntu modprobe hack from debian/rules
 
- -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:15 +0100
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Fri, 20 May 2016 01:39:53 +0100
 
 bumblebee (3.2.1-95~trustyppa2) trusty; urgency=medium
 

--- a/trusty/bumblebee/debian/changelog
+++ b/trusty/bumblebee/debian/changelog
@@ -3,6 +3,7 @@ bumblebee (3.2.1-96~trustyppa1) UNRELEASED; urgency=medium
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
+  * Remove Ubuntu modprobe hack from debian/rules
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:15 +0100
 

--- a/trusty/bumblebee/debian/changelog
+++ b/trusty/bumblebee/debian/changelog
@@ -1,3 +1,11 @@
+bumblebee (3.2.1-96~trustyppa1) UNRELEASED; urgency=medium
+
+  * Backport libkmod.patch from upstream develop branch and add build-dep
+    on libkmod-dev. Definitively fixes all issues with multiple kernel
+    modules loading/unloading.
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:15 +0100
+
 bumblebee (3.2.1-95~trustyppa2) trusty; urgency=medium
 
   * Revert using dh_strip --dbgsym-migration, fixes FTBS

--- a/trusty/bumblebee/debian/control
+++ b/trusty/bumblebee/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  libglib2.0-dev,
  libx11-dev,
  pkg-config,
+ libkmod-dev,
 Standards-Version: 3.9.5
 Homepage: https://launchpad.net/~bumblebee
 Vcs-Browser: https://github.com/Bumblebee-Project/Bumblebee

--- a/trusty/bumblebee/debian/patches/libkmod.patch
+++ b/trusty/bumblebee/debian/patches/libkmod.patch
@@ -1,0 +1,434 @@
+From: =?utf-8?q?Ond=C5=99ej_Jano=C5=A1=C3=ADk?= <j.ondra14@gmail.com>
+Date: Thu, 5 May 2016 18:48:43 +0200
+Subject: module: use libkmod2 instead of modprobe
+
+---
+ Makefile.am      |   8 +--
+ README.markdown  |   1 +
+ configure.ac     |   1 +
+ src/bbconfig.c   |  12 ++--
+ src/bbconfig.h   |   2 +
+ src/bblogger.c   |   4 +-
+ src/bumblebeed.c |  12 ++++
+ src/module.c     | 185 +++++++++++++++++++++++++++++++++++++------------------
+ src/optirun.c    |   1 -
+ 9 files changed, 152 insertions(+), 74 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0f38a54..25e32d5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -10,7 +10,7 @@ AM_CPPFLAGS = ${regular_CPPFLAGS} \
+ 		-DCONF_XORG='"$(bumblebeedconfdir)/xorg.conf.DRIVER"' \
+ 		-DCONF_XORG_DIR='"$(bumblebeedconfdir)/xorg.conf.d"'
+ AM_CFLAGS = ${regular_CFLAGS} \
+-		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} \
++		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} ${kmod_CFLAGS} \
+ 		-Wextra -funsigned-char -DGITVERSION='"${GITVERSION}"'
+ 
+ noinst_SCRIPTS = scripts/systemd/bumblebeed.service \
+@@ -49,13 +49,13 @@ sbin_PROGRAMS = bin/bumblebeed
+ bin_PROGRAMS = bin/optirun
+ 
+ bin_optirun_SOURCES = src/module.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+-	src/bbsocket.c src/driver.c src/optirun.c src/bbsocketclient.c
+-bin_optirun_LDADD = ${glib_LIBS} -lrt
++	src/bbsocket.c src/optirun.c src/bbsocketclient.c
++bin_optirun_LDADD = ${glib_LIBS} ${kmod_LIBS} -lrt
+ bin_bumblebeed_SOURCES = src/pci.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+ 	src/bbsocket.c src/module.c src/bbsecondary.c src/switch/switching.c \
+ 	src/switch/sw_bbswitch.c src/switch/sw_switcheroo.c \
+ 	src/driver.c src/bumblebeed.c
+-bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} -lrt
++bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} ${kmod_LIBS} -lrt
+ 
+ dist_doc_DATA = $(relnotes) README.markdown
+ bumblebeedconf_DATA = conf/bumblebee.conf conf/xorg.conf.nouveau conf/xorg.conf.nvidia
+diff --git a/README.markdown b/README.markdown
+index b534a6c..5c2baa5 100644
+--- a/README.markdown
++++ b/README.markdown
+@@ -19,6 +19,7 @@ The following packages are dependencies for the build process:
+ - pkg-config
+ - glib-2.0 and development headers
+ - libx11 and development headers
++- libkmod2 and development headers
+ - libbsd and development headers (if pidfile support is enabled, default yes)
+ - help2man (optional, it is needed for building manual pages)
+ 
+diff --git a/configure.ac b/configure.ac
+index 4e22314..d5194b8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,7 @@ AC_SUBST([regular_CFLAGS])
+ # Checks for header files.
+ PKG_CHECK_MODULES([x11], [x11])
+ PKG_CHECK_MODULES([glib], [glib-2.0])
++PKG_CHECK_MODULES([kmod], [libkmod])
+ AS_IF([test "x$with_pidfile" != xno], [
+ 		PKG_CHECK_MODULES([libbsd], [libbsd >= 0.2.0])
+ 		PKG_CHECK_EXISTS([libbsd = 0.2.0], [AC_DEFINE(HAVE_LIBBSD_020)])
+diff --git a/src/bbconfig.c b/src/bbconfig.c
+index 4f5ac7a..62a3306 100644
+--- a/src/bbconfig.c
++++ b/src/bbconfig.c
+@@ -251,12 +251,6 @@ Bumblebee homepage: <http://Bumblebee-Project.org/>\n", out);
+  */
+ static int bbconfig_parse_common(int opt, char *value) {
+   switch (opt) {
+-    case 'q'://quiet mode
+-      bb_status.verbosity = VERB_NONE;
+-      break;
+-    case OPT_DEBUG://debug mode
+-      bb_status.verbosity = VERB_ALL;
+-      break;
+     case 'd'://X display number
+       set_string_value(&bb_config.x_display, value);
+       break;
+@@ -307,6 +301,12 @@ void bbconfig_parse_opts(int argc, char *argv[], int conf_round) {
+             bb_status.verbosity++;
+           }
+           break;
++        case 'q'://quiet mode
++          bb_status.verbosity = VERB_NONE;
++          break;
++        case OPT_DEBUG://debug mode
++          bb_status.verbosity = VERB_ALL;
++          break;
+         case 's': /* Unix socket to use for communication */
+           set_string_value(&bb_config.socket_path, optarg);
+           break;
+diff --git a/src/bbconfig.h b/src/bbconfig.h
+index 656286b..a19f5d3 100644
+--- a/src/bbconfig.h
++++ b/src/bbconfig.h
+@@ -26,6 +26,7 @@
+ #include <unistd.h> //for pid_t
+ #include <limits.h> //for CHAR_MAX
+ #include <glib.h>
++#include <libkmod.h>
+ 
+ /* Daemon states */
+ #define BB_DAEMON 1
+@@ -118,6 +119,7 @@ struct bb_status_struct {
+     int x_pipe[2];//pipes for reading/writing output from X's stdout/stderr
+     gboolean use_syslog;
+     char *program_name;
++    struct kmod_ctx *kmod_ctx;
+ };
+ 
+ /* Structure containing the configuration. */
+diff --git a/src/bblogger.c b/src/bblogger.c
+index ba3787e..7c13c93 100644
+--- a/src/bblogger.c
++++ b/src/bblogger.c
+@@ -228,7 +228,7 @@ void check_xorg_pipe(void){
+         /* line / buffer is full, process the remaining buffer the next round */
+         repeat = 1;
+       }
+-    }else{
++    } else {
+       if (r == 0 || (errno != EAGAIN && r == -1)){
+         /* the pipe is closed/invalid. Clean up. */
+         if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+@@ -257,5 +257,5 @@ void check_xorg_pipe(void){
+         memmove(x_output_buffer, next_part, x_buffer_pos);
+       }
+     }
+-  }while(repeat);
++  }while (repeat);
+ }/* check_xorg_pipe */
+diff --git a/src/bumblebeed.c b/src/bumblebeed.c
+index a911da9..6e0ade5 100644
+--- a/src/bumblebeed.c
++++ b/src/bumblebeed.c
+@@ -34,6 +34,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <getopt.h>
++#include <libkmod.h>
+ #ifdef WITH_PIDFILE
+ #ifdef HAVE_LIBBSD_020
+ #include <libutil.h>
+@@ -488,6 +489,14 @@ int main(int argc, char* argv[]) {
+ 
+   free(pci_id_igd);
+ 
++  // kmod context have to be available for driver detection
++  bb_status.kmod_ctx = kmod_new(NULL, NULL);
++  if (bb_status.kmod_ctx == NULL) {
++    bb_log(LOG_ERR, "kmod_new() failed!\n");
++    bb_closelog();
++    exit(EXIT_FAILURE);
++  }
++
+   GKeyFile *bbcfg = bbconfig_parse_conf();
+   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);
+   driver_detect();
+@@ -500,6 +509,7 @@ int main(int argc, char* argv[]) {
+ 
+   /* dump the config after detecting the driver */
+   config_dump();
++
+   if (config_validate() != 0) {
+     return (EXIT_FAILURE);
+   }
+@@ -572,5 +582,7 @@ int main(int argc, char* argv[]) {
+   //close X pipe, if any parts of it are open still
+   if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+   if (bb_status.x_pipe[1] != -1){close(bb_status.x_pipe[1]); bb_status.x_pipe[1] = -1;}
++  //cleanup kmod context
++  kmod_unref(bb_status.kmod_ctx);
+   return (EXIT_SUCCESS);
+ }
+diff --git a/src/module.c b/src/module.c
+index bb32e15..ef3e84c 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -24,91 +24,152 @@
+ #include <ctype.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <libkmod.h>
++#include <errno.h>
+ #include "module.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
++#include "bbconfig.h"
++
++int module_unload_recursive(struct kmod_module *mod);
+ 
+ /**
+- * Checks in /proc/modules whether a kernel module is loaded
++ * Checks whether a kernel module is loaded
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the module is loaded, 0 otherwise
+  */
+ int module_is_loaded(char *driver) {
+-  // use the same buffer length as lsmod
+-  char buffer[4096];
+-  FILE * bbs = fopen("/proc/modules", "r");
+-  int ret = 0;
+-  /* assume mod_len <= sizeof(buffer) */
+-  int mod_len = strlen(driver);
++  int err, state;
++  struct kmod_module *mod;
+ 
+-  if (bbs == 0) {//error opening, return -1
+-    bb_log(LOG_DEBUG, "Couldn't open /proc/modules");
+-    return -1;
++  err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++      driver, err);
++    return 0;
+   }
+-  while (fgets(buffer, sizeof(buffer), bbs)) {
+-    /* match "module" with "module " and not "module-blah" */
+-    if (!strncmp(buffer, driver, mod_len) && isspace(buffer[mod_len])) {
+-      /* module is found */
+-      ret = 1;
+-      break;
+-    }
+-  }
+-  fclose(bbs);
+-  return ret;
++
++  state = kmod_module_get_initstate(mod);
++  kmod_module_unref(mod);
++
++  return state == KMOD_MODULE_LIVE;
+ }
+ 
+ /**
+- * Attempts to load a module. If the module has not been loaded after ten
+- * seconds, give up
++ * Attempts to load a module.
+  *
+  * @param module_name The filename of the module to be loaded
+  * @param driver The name of the driver to be loaded
+  * @return 1 if the driver is successfully loaded, 0 otherwise
+  */
+ int module_load(char *module_name, char *driver) {
++  int err = 0;
++  int flags = KMOD_PROBE_IGNORE_LOADED;
++  struct kmod_list *l, *list = NULL;
++
+   if (module_is_loaded(driver) == 0) {
+     /* the module has not loaded yet, try to load it */
+-    bb_log(LOG_INFO, "Loading driver %s (module %s)\n", driver, module_name);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      module_name,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    if (module_is_loaded(driver) == 0) {
+-      bb_log(LOG_ERR, "Module %s could not be loaded (timeout?)\n", module_name);
++
++    bb_log(LOG_INFO, "Loading driver '%s' (module '%s')\n", driver, module_name);
++    err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++        module_name, err);
++      return 0;
++    }
++
++    if (list == NULL) {
++      bb_log(LOG_ERR, "Module '%s' not found.\n", module_name);
+       return 0;
+     }
++
++    kmod_list_foreach(l, list) {
++      struct kmod_module *mod = kmod_module_get_module(l);
++
++      bb_log(LOG_DEBUG, "Loading module '%s'.\n", kmod_module_get_name(mod));
++      err = kmod_module_probe_insert_module(mod, flags, NULL, NULL, NULL, 0);
++
++      if (err < 0) {
++        bb_log(LOG_DEBUG, "kmod_module_probe_insert_module(%s) failed (err: %d).\n",
++          kmod_module_get_name(mod), err);
++      }
++
++      kmod_module_unref(mod);
++
++      if (err < 0) {
++        break;
++      }
++    }
++
++    kmod_module_unref_list(list);
++  }
++
++  return err >= 0;
++}
++
++/**
++ * Unloads module and modules that are depending on this module.
++ *
++ * @param mod Reference to libkmod module
++ * @return 1 if the module is successfully unloaded, 0 otherwise
++ */
++int module_unload_recursive(struct kmod_module *mod) {
++  int err = 0, flags = 0, refcnt;
++  struct kmod_list *holders;
++
++  holders = kmod_module_get_holders(mod);
++  if (holders != NULL) {
++    struct kmod_list *itr;
++
++    kmod_list_foreach(itr, holders) {
++      struct kmod_module *hm = kmod_module_get_module(itr);
++      err = module_unload_recursive(hm);
++      kmod_module_unref(hm);
++
++      if (err < 0) {
++        break;
++      }
++    }
++    kmod_module_unref_list(holders);
+   }
+-  return 1;
++
++  refcnt = kmod_module_get_refcnt(mod);
++  if (refcnt == 0) {
++    bb_log(LOG_INFO, "Unloading module %s\n", kmod_module_get_name(mod));
++    err = kmod_module_remove_module(mod, flags);
++  } else {
++    bb_log(LOG_ERR, "Failed to unload module '%s' (ref count: %d).\n",
++      kmod_module_get_name(mod), refcnt);
++    err = 1;
++  }
++
++  return err == 0;
+ }
+ 
+ /**
+- * Attempts to unload a module if loaded, for ten seconds before
+- * giving up
++ * Attempts to unload a module if loaded.
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the driver is successfully unloaded, 0 otherwise
+  */
+ int module_unload(char *driver) {
++  int err;
++  struct kmod_module *mod;
+   if (module_is_loaded(driver) == 1) {
+-    int retries = 30;
+-    bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      "-r",
+-      driver,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    while (retries-- > 0 && module_is_loaded(driver) == 1) {
+-      usleep(100000);
+-    }
+-    if (module_is_loaded(driver) == 1) {
+-      bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
++    err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++        driver, err);
+       return 0;
+     }
++
++    err = module_unload_recursive(mod);
++    kmod_module_unref(mod);
++
++    return err;
+   }
+   return 1;
+ }
+@@ -120,18 +181,20 @@ int module_unload(char *driver) {
+  * @return 1 if the module is available for loading, 0 otherwise
+  */
+ int module_is_available(char *module_name) {
+-  /* HACK to support call from optirun */
+-  char *modprobe_bin = "/sbin/modprobe";
+-  if (access(modprobe_bin, X_OK)) {
+-    /* if /sbin/modprobe is not found, pray that PATH contains it */
+-    modprobe_bin = "modprobe";
++  int err, available;
++  struct kmod_list *list = NULL;
++
++  err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++      module_name, err);
++    return 0;
+   }
+-  char *mod_argv[] = {
+-    modprobe_bin,
+-    "--dry-run",
+-    "--quiet",
+-    module_name,
+-    NULL
+-  };
+-  return bb_run_fork(mod_argv, 1) == EXIT_SUCCESS;
++
++  available = list != NULL;
++
++  kmod_module_unref_list(list);
++
++  return available;
+ }
+diff --git a/src/optirun.c b/src/optirun.c
+index bcc6c13..f05f05c 100644
+--- a/src/optirun.c
++++ b/src/optirun.c
+@@ -37,7 +37,6 @@
+ #include "bbsocketclient.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
+-#include "driver.h"
+ 
+ 
+ /**

--- a/trusty/bumblebee/debian/patches/series
+++ b/trusty/bumblebee/debian/patches/series
@@ -5,3 +5,4 @@ fix-typos.patch
 xorg-binary-config.patch
 ignore-systemd-logind-noise.patch
 ignore-failure-to-set-DRM-interface.patch
+libkmod.patch

--- a/trusty/bumblebee/debian/rules
+++ b/trusty/bumblebee/debian/rules
@@ -48,13 +48,6 @@ override_dh_install:
 	   debian/bumblebee/usr/share/bash-completion/completions/
 	rm -rf debian/bumblebee/etc/bash_completion.d/
 
-ifeq ($(VENDOR),Ubuntu)
-	# On Ubuntu modprobe remove line is not present, which breaks module
-	# unloading; https://github.com/Bumblebee-Project/Bumblebee/issues/681
-	echo "# Workaround to make sure nvidia-uvm is removed as well" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-	echo "remove nvidia rmmod nvidia-uvm nvidia" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-endif
-
 override_dh_installinit:
 	dh_installinit --name=bumblebeed
 

--- a/vivid/bumblebee/debian/changelog
+++ b/vivid/bumblebee/debian/changelog
@@ -1,3 +1,11 @@
+bumblebee (3.2.1-96~vividppa1) UNRELEASED; urgency=medium
+
+  * Backport libkmod.patch from upstream develop branch and add build-dep
+    on libkmod-dev. Definitively fixes all issues with multiple kernel
+    modules loading/unloading.
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:01 +0100
+
 bumblebee (3.2.1-95~vividppa2) vivid; urgency=medium
 
   * Revert using dh_strip --dbgsym-migration, fixes FTBS

--- a/vivid/bumblebee/debian/changelog
+++ b/vivid/bumblebee/debian/changelog
@@ -3,6 +3,7 @@ bumblebee (3.2.1-96~vividppa1) UNRELEASED; urgency=medium
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
+  * Remove Ubuntu modprobe hack from debian/rules
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:01 +0100
 

--- a/vivid/bumblebee/debian/changelog
+++ b/vivid/bumblebee/debian/changelog
@@ -1,11 +1,11 @@
-bumblebee (3.2.1-96~vividppa1) UNRELEASED; urgency=medium
+bumblebee (3.2.1-96~vividppa1) vivid; urgency=medium
 
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
   * Remove Ubuntu modprobe hack from debian/rules
 
- -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:01 +0100
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Fri, 20 May 2016 01:40:06 +0100
 
 bumblebee (3.2.1-95~vividppa2) vivid; urgency=medium
 

--- a/vivid/bumblebee/debian/control
+++ b/vivid/bumblebee/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  libglib2.0-dev,
  libx11-dev,
  pkg-config,
+ libkmod-dev,
 Standards-Version: 3.9.5
 Homepage: https://launchpad.net/~bumblebee
 Vcs-Browser: https://github.com/Bumblebee-Project/Bumblebee

--- a/vivid/bumblebee/debian/patches/libkmod.patch
+++ b/vivid/bumblebee/debian/patches/libkmod.patch
@@ -1,0 +1,434 @@
+From: =?utf-8?q?Ond=C5=99ej_Jano=C5=A1=C3=ADk?= <j.ondra14@gmail.com>
+Date: Thu, 5 May 2016 18:48:43 +0200
+Subject: module: use libkmod2 instead of modprobe
+
+---
+ Makefile.am      |   8 +--
+ README.markdown  |   1 +
+ configure.ac     |   1 +
+ src/bbconfig.c   |  12 ++--
+ src/bbconfig.h   |   2 +
+ src/bblogger.c   |   4 +-
+ src/bumblebeed.c |  12 ++++
+ src/module.c     | 185 +++++++++++++++++++++++++++++++++++++------------------
+ src/optirun.c    |   1 -
+ 9 files changed, 152 insertions(+), 74 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0f38a54..25e32d5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -10,7 +10,7 @@ AM_CPPFLAGS = ${regular_CPPFLAGS} \
+ 		-DCONF_XORG='"$(bumblebeedconfdir)/xorg.conf.DRIVER"' \
+ 		-DCONF_XORG_DIR='"$(bumblebeedconfdir)/xorg.conf.d"'
+ AM_CFLAGS = ${regular_CFLAGS} \
+-		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} \
++		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} ${kmod_CFLAGS} \
+ 		-Wextra -funsigned-char -DGITVERSION='"${GITVERSION}"'
+ 
+ noinst_SCRIPTS = scripts/systemd/bumblebeed.service \
+@@ -49,13 +49,13 @@ sbin_PROGRAMS = bin/bumblebeed
+ bin_PROGRAMS = bin/optirun
+ 
+ bin_optirun_SOURCES = src/module.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+-	src/bbsocket.c src/driver.c src/optirun.c src/bbsocketclient.c
+-bin_optirun_LDADD = ${glib_LIBS} -lrt
++	src/bbsocket.c src/optirun.c src/bbsocketclient.c
++bin_optirun_LDADD = ${glib_LIBS} ${kmod_LIBS} -lrt
+ bin_bumblebeed_SOURCES = src/pci.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+ 	src/bbsocket.c src/module.c src/bbsecondary.c src/switch/switching.c \
+ 	src/switch/sw_bbswitch.c src/switch/sw_switcheroo.c \
+ 	src/driver.c src/bumblebeed.c
+-bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} -lrt
++bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} ${kmod_LIBS} -lrt
+ 
+ dist_doc_DATA = $(relnotes) README.markdown
+ bumblebeedconf_DATA = conf/bumblebee.conf conf/xorg.conf.nouveau conf/xorg.conf.nvidia
+diff --git a/README.markdown b/README.markdown
+index b534a6c..5c2baa5 100644
+--- a/README.markdown
++++ b/README.markdown
+@@ -19,6 +19,7 @@ The following packages are dependencies for the build process:
+ - pkg-config
+ - glib-2.0 and development headers
+ - libx11 and development headers
++- libkmod2 and development headers
+ - libbsd and development headers (if pidfile support is enabled, default yes)
+ - help2man (optional, it is needed for building manual pages)
+ 
+diff --git a/configure.ac b/configure.ac
+index 4e22314..d5194b8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,7 @@ AC_SUBST([regular_CFLAGS])
+ # Checks for header files.
+ PKG_CHECK_MODULES([x11], [x11])
+ PKG_CHECK_MODULES([glib], [glib-2.0])
++PKG_CHECK_MODULES([kmod], [libkmod])
+ AS_IF([test "x$with_pidfile" != xno], [
+ 		PKG_CHECK_MODULES([libbsd], [libbsd >= 0.2.0])
+ 		PKG_CHECK_EXISTS([libbsd = 0.2.0], [AC_DEFINE(HAVE_LIBBSD_020)])
+diff --git a/src/bbconfig.c b/src/bbconfig.c
+index 4f5ac7a..62a3306 100644
+--- a/src/bbconfig.c
++++ b/src/bbconfig.c
+@@ -251,12 +251,6 @@ Bumblebee homepage: <http://Bumblebee-Project.org/>\n", out);
+  */
+ static int bbconfig_parse_common(int opt, char *value) {
+   switch (opt) {
+-    case 'q'://quiet mode
+-      bb_status.verbosity = VERB_NONE;
+-      break;
+-    case OPT_DEBUG://debug mode
+-      bb_status.verbosity = VERB_ALL;
+-      break;
+     case 'd'://X display number
+       set_string_value(&bb_config.x_display, value);
+       break;
+@@ -307,6 +301,12 @@ void bbconfig_parse_opts(int argc, char *argv[], int conf_round) {
+             bb_status.verbosity++;
+           }
+           break;
++        case 'q'://quiet mode
++          bb_status.verbosity = VERB_NONE;
++          break;
++        case OPT_DEBUG://debug mode
++          bb_status.verbosity = VERB_ALL;
++          break;
+         case 's': /* Unix socket to use for communication */
+           set_string_value(&bb_config.socket_path, optarg);
+           break;
+diff --git a/src/bbconfig.h b/src/bbconfig.h
+index 656286b..a19f5d3 100644
+--- a/src/bbconfig.h
++++ b/src/bbconfig.h
+@@ -26,6 +26,7 @@
+ #include <unistd.h> //for pid_t
+ #include <limits.h> //for CHAR_MAX
+ #include <glib.h>
++#include <libkmod.h>
+ 
+ /* Daemon states */
+ #define BB_DAEMON 1
+@@ -118,6 +119,7 @@ struct bb_status_struct {
+     int x_pipe[2];//pipes for reading/writing output from X's stdout/stderr
+     gboolean use_syslog;
+     char *program_name;
++    struct kmod_ctx *kmod_ctx;
+ };
+ 
+ /* Structure containing the configuration. */
+diff --git a/src/bblogger.c b/src/bblogger.c
+index ba3787e..7c13c93 100644
+--- a/src/bblogger.c
++++ b/src/bblogger.c
+@@ -228,7 +228,7 @@ void check_xorg_pipe(void){
+         /* line / buffer is full, process the remaining buffer the next round */
+         repeat = 1;
+       }
+-    }else{
++    } else {
+       if (r == 0 || (errno != EAGAIN && r == -1)){
+         /* the pipe is closed/invalid. Clean up. */
+         if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+@@ -257,5 +257,5 @@ void check_xorg_pipe(void){
+         memmove(x_output_buffer, next_part, x_buffer_pos);
+       }
+     }
+-  }while(repeat);
++  }while (repeat);
+ }/* check_xorg_pipe */
+diff --git a/src/bumblebeed.c b/src/bumblebeed.c
+index a911da9..6e0ade5 100644
+--- a/src/bumblebeed.c
++++ b/src/bumblebeed.c
+@@ -34,6 +34,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <getopt.h>
++#include <libkmod.h>
+ #ifdef WITH_PIDFILE
+ #ifdef HAVE_LIBBSD_020
+ #include <libutil.h>
+@@ -488,6 +489,14 @@ int main(int argc, char* argv[]) {
+ 
+   free(pci_id_igd);
+ 
++  // kmod context have to be available for driver detection
++  bb_status.kmod_ctx = kmod_new(NULL, NULL);
++  if (bb_status.kmod_ctx == NULL) {
++    bb_log(LOG_ERR, "kmod_new() failed!\n");
++    bb_closelog();
++    exit(EXIT_FAILURE);
++  }
++
+   GKeyFile *bbcfg = bbconfig_parse_conf();
+   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);
+   driver_detect();
+@@ -500,6 +509,7 @@ int main(int argc, char* argv[]) {
+ 
+   /* dump the config after detecting the driver */
+   config_dump();
++
+   if (config_validate() != 0) {
+     return (EXIT_FAILURE);
+   }
+@@ -572,5 +582,7 @@ int main(int argc, char* argv[]) {
+   //close X pipe, if any parts of it are open still
+   if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+   if (bb_status.x_pipe[1] != -1){close(bb_status.x_pipe[1]); bb_status.x_pipe[1] = -1;}
++  //cleanup kmod context
++  kmod_unref(bb_status.kmod_ctx);
+   return (EXIT_SUCCESS);
+ }
+diff --git a/src/module.c b/src/module.c
+index bb32e15..ef3e84c 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -24,91 +24,152 @@
+ #include <ctype.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <libkmod.h>
++#include <errno.h>
+ #include "module.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
++#include "bbconfig.h"
++
++int module_unload_recursive(struct kmod_module *mod);
+ 
+ /**
+- * Checks in /proc/modules whether a kernel module is loaded
++ * Checks whether a kernel module is loaded
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the module is loaded, 0 otherwise
+  */
+ int module_is_loaded(char *driver) {
+-  // use the same buffer length as lsmod
+-  char buffer[4096];
+-  FILE * bbs = fopen("/proc/modules", "r");
+-  int ret = 0;
+-  /* assume mod_len <= sizeof(buffer) */
+-  int mod_len = strlen(driver);
++  int err, state;
++  struct kmod_module *mod;
+ 
+-  if (bbs == 0) {//error opening, return -1
+-    bb_log(LOG_DEBUG, "Couldn't open /proc/modules");
+-    return -1;
++  err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++      driver, err);
++    return 0;
+   }
+-  while (fgets(buffer, sizeof(buffer), bbs)) {
+-    /* match "module" with "module " and not "module-blah" */
+-    if (!strncmp(buffer, driver, mod_len) && isspace(buffer[mod_len])) {
+-      /* module is found */
+-      ret = 1;
+-      break;
+-    }
+-  }
+-  fclose(bbs);
+-  return ret;
++
++  state = kmod_module_get_initstate(mod);
++  kmod_module_unref(mod);
++
++  return state == KMOD_MODULE_LIVE;
+ }
+ 
+ /**
+- * Attempts to load a module. If the module has not been loaded after ten
+- * seconds, give up
++ * Attempts to load a module.
+  *
+  * @param module_name The filename of the module to be loaded
+  * @param driver The name of the driver to be loaded
+  * @return 1 if the driver is successfully loaded, 0 otherwise
+  */
+ int module_load(char *module_name, char *driver) {
++  int err = 0;
++  int flags = KMOD_PROBE_IGNORE_LOADED;
++  struct kmod_list *l, *list = NULL;
++
+   if (module_is_loaded(driver) == 0) {
+     /* the module has not loaded yet, try to load it */
+-    bb_log(LOG_INFO, "Loading driver %s (module %s)\n", driver, module_name);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      module_name,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    if (module_is_loaded(driver) == 0) {
+-      bb_log(LOG_ERR, "Module %s could not be loaded (timeout?)\n", module_name);
++
++    bb_log(LOG_INFO, "Loading driver '%s' (module '%s')\n", driver, module_name);
++    err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++        module_name, err);
++      return 0;
++    }
++
++    if (list == NULL) {
++      bb_log(LOG_ERR, "Module '%s' not found.\n", module_name);
+       return 0;
+     }
++
++    kmod_list_foreach(l, list) {
++      struct kmod_module *mod = kmod_module_get_module(l);
++
++      bb_log(LOG_DEBUG, "Loading module '%s'.\n", kmod_module_get_name(mod));
++      err = kmod_module_probe_insert_module(mod, flags, NULL, NULL, NULL, 0);
++
++      if (err < 0) {
++        bb_log(LOG_DEBUG, "kmod_module_probe_insert_module(%s) failed (err: %d).\n",
++          kmod_module_get_name(mod), err);
++      }
++
++      kmod_module_unref(mod);
++
++      if (err < 0) {
++        break;
++      }
++    }
++
++    kmod_module_unref_list(list);
++  }
++
++  return err >= 0;
++}
++
++/**
++ * Unloads module and modules that are depending on this module.
++ *
++ * @param mod Reference to libkmod module
++ * @return 1 if the module is successfully unloaded, 0 otherwise
++ */
++int module_unload_recursive(struct kmod_module *mod) {
++  int err = 0, flags = 0, refcnt;
++  struct kmod_list *holders;
++
++  holders = kmod_module_get_holders(mod);
++  if (holders != NULL) {
++    struct kmod_list *itr;
++
++    kmod_list_foreach(itr, holders) {
++      struct kmod_module *hm = kmod_module_get_module(itr);
++      err = module_unload_recursive(hm);
++      kmod_module_unref(hm);
++
++      if (err < 0) {
++        break;
++      }
++    }
++    kmod_module_unref_list(holders);
+   }
+-  return 1;
++
++  refcnt = kmod_module_get_refcnt(mod);
++  if (refcnt == 0) {
++    bb_log(LOG_INFO, "Unloading module %s\n", kmod_module_get_name(mod));
++    err = kmod_module_remove_module(mod, flags);
++  } else {
++    bb_log(LOG_ERR, "Failed to unload module '%s' (ref count: %d).\n",
++      kmod_module_get_name(mod), refcnt);
++    err = 1;
++  }
++
++  return err == 0;
+ }
+ 
+ /**
+- * Attempts to unload a module if loaded, for ten seconds before
+- * giving up
++ * Attempts to unload a module if loaded.
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the driver is successfully unloaded, 0 otherwise
+  */
+ int module_unload(char *driver) {
++  int err;
++  struct kmod_module *mod;
+   if (module_is_loaded(driver) == 1) {
+-    int retries = 30;
+-    bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      "-r",
+-      driver,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    while (retries-- > 0 && module_is_loaded(driver) == 1) {
+-      usleep(100000);
+-    }
+-    if (module_is_loaded(driver) == 1) {
+-      bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
++    err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++        driver, err);
+       return 0;
+     }
++
++    err = module_unload_recursive(mod);
++    kmod_module_unref(mod);
++
++    return err;
+   }
+   return 1;
+ }
+@@ -120,18 +181,20 @@ int module_unload(char *driver) {
+  * @return 1 if the module is available for loading, 0 otherwise
+  */
+ int module_is_available(char *module_name) {
+-  /* HACK to support call from optirun */
+-  char *modprobe_bin = "/sbin/modprobe";
+-  if (access(modprobe_bin, X_OK)) {
+-    /* if /sbin/modprobe is not found, pray that PATH contains it */
+-    modprobe_bin = "modprobe";
++  int err, available;
++  struct kmod_list *list = NULL;
++
++  err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++      module_name, err);
++    return 0;
+   }
+-  char *mod_argv[] = {
+-    modprobe_bin,
+-    "--dry-run",
+-    "--quiet",
+-    module_name,
+-    NULL
+-  };
+-  return bb_run_fork(mod_argv, 1) == EXIT_SUCCESS;
++
++  available = list != NULL;
++
++  kmod_module_unref_list(list);
++
++  return available;
+ }
+diff --git a/src/optirun.c b/src/optirun.c
+index bcc6c13..f05f05c 100644
+--- a/src/optirun.c
++++ b/src/optirun.c
+@@ -37,7 +37,6 @@
+ #include "bbsocketclient.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
+-#include "driver.h"
+ 
+ 
+ /**

--- a/vivid/bumblebee/debian/patches/series
+++ b/vivid/bumblebee/debian/patches/series
@@ -5,3 +5,4 @@ fix-typos.patch
 xorg-binary-config.patch
 ignore-systemd-logind-noise.patch
 ignore-failure-to-set-DRM-interface.patch
+libkmod.patch

--- a/vivid/bumblebee/debian/rules
+++ b/vivid/bumblebee/debian/rules
@@ -48,13 +48,6 @@ override_dh_install:
 	   debian/bumblebee/usr/share/bash-completion/completions/
 	rm -rf debian/bumblebee/etc/bash_completion.d/
 
-ifeq ($(VENDOR),Ubuntu)
-	# On Ubuntu modprobe remove line is not present, which breaks module
-	# unloading; https://github.com/Bumblebee-Project/Bumblebee/issues/681
-	echo "# Workaround to make sure nvidia-uvm is removed as well" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-	echo "remove nvidia rmmod nvidia-uvm nvidia" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-endif
-
 override_dh_installinit:
 	dh_installinit --name=bumblebeed
 

--- a/wily/bumblebee/debian/changelog
+++ b/wily/bumblebee/debian/changelog
@@ -1,3 +1,11 @@
+bumblebee (3.2.1-96~wilyppa1) UNRELEASED; urgency=medium
+
+  * Backport libkmod.patch from upstream develop branch and add build-dep
+    on libkmod-dev. Definitively fixes all issues with multiple kernel
+    modules loading/unloading.
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:29 +0100
+
 bumblebee (3.2.1-95~wilyppa2) wily; urgency=medium
 
   * Revert using dh_strip --dbgsym-migration, fixes FTBS

--- a/wily/bumblebee/debian/changelog
+++ b/wily/bumblebee/debian/changelog
@@ -3,6 +3,7 @@ bumblebee (3.2.1-96~wilyppa1) UNRELEASED; urgency=medium
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
+  * Remove Ubuntu modprobe hack from debian/rules
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:29 +0100
 

--- a/wily/bumblebee/debian/changelog
+++ b/wily/bumblebee/debian/changelog
@@ -1,11 +1,11 @@
-bumblebee (3.2.1-96~wilyppa1) UNRELEASED; urgency=medium
+bumblebee (3.2.1-96~wilyppa1) wily; urgency=medium
 
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
   * Remove Ubuntu modprobe hack from debian/rules
 
- -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:29 +0100
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Fri, 20 May 2016 01:40:19 +0100
 
 bumblebee (3.2.1-95~wilyppa2) wily; urgency=medium
 

--- a/wily/bumblebee/debian/control
+++ b/wily/bumblebee/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  libglib2.0-dev,
  libx11-dev,
  pkg-config,
+ libkmod-dev,
 Standards-Version: 3.9.5
 Homepage: https://launchpad.net/~bumblebee
 Vcs-Browser: https://github.com/Bumblebee-Project/Bumblebee

--- a/wily/bumblebee/debian/patches/libkmod.patch
+++ b/wily/bumblebee/debian/patches/libkmod.patch
@@ -1,0 +1,434 @@
+From: =?utf-8?q?Ond=C5=99ej_Jano=C5=A1=C3=ADk?= <j.ondra14@gmail.com>
+Date: Thu, 5 May 2016 18:48:43 +0200
+Subject: module: use libkmod2 instead of modprobe
+
+---
+ Makefile.am      |   8 +--
+ README.markdown  |   1 +
+ configure.ac     |   1 +
+ src/bbconfig.c   |  12 ++--
+ src/bbconfig.h   |   2 +
+ src/bblogger.c   |   4 +-
+ src/bumblebeed.c |  12 ++++
+ src/module.c     | 185 +++++++++++++++++++++++++++++++++++++------------------
+ src/optirun.c    |   1 -
+ 9 files changed, 152 insertions(+), 74 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0f38a54..25e32d5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -10,7 +10,7 @@ AM_CPPFLAGS = ${regular_CPPFLAGS} \
+ 		-DCONF_XORG='"$(bumblebeedconfdir)/xorg.conf.DRIVER"' \
+ 		-DCONF_XORG_DIR='"$(bumblebeedconfdir)/xorg.conf.d"'
+ AM_CFLAGS = ${regular_CFLAGS} \
+-		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} \
++		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} ${kmod_CFLAGS} \
+ 		-Wextra -funsigned-char -DGITVERSION='"${GITVERSION}"'
+ 
+ noinst_SCRIPTS = scripts/systemd/bumblebeed.service \
+@@ -49,13 +49,13 @@ sbin_PROGRAMS = bin/bumblebeed
+ bin_PROGRAMS = bin/optirun
+ 
+ bin_optirun_SOURCES = src/module.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+-	src/bbsocket.c src/driver.c src/optirun.c src/bbsocketclient.c
+-bin_optirun_LDADD = ${glib_LIBS} -lrt
++	src/bbsocket.c src/optirun.c src/bbsocketclient.c
++bin_optirun_LDADD = ${glib_LIBS} ${kmod_LIBS} -lrt
+ bin_bumblebeed_SOURCES = src/pci.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+ 	src/bbsocket.c src/module.c src/bbsecondary.c src/switch/switching.c \
+ 	src/switch/sw_bbswitch.c src/switch/sw_switcheroo.c \
+ 	src/driver.c src/bumblebeed.c
+-bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} -lrt
++bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} ${kmod_LIBS} -lrt
+ 
+ dist_doc_DATA = $(relnotes) README.markdown
+ bumblebeedconf_DATA = conf/bumblebee.conf conf/xorg.conf.nouveau conf/xorg.conf.nvidia
+diff --git a/README.markdown b/README.markdown
+index b534a6c..5c2baa5 100644
+--- a/README.markdown
++++ b/README.markdown
+@@ -19,6 +19,7 @@ The following packages are dependencies for the build process:
+ - pkg-config
+ - glib-2.0 and development headers
+ - libx11 and development headers
++- libkmod2 and development headers
+ - libbsd and development headers (if pidfile support is enabled, default yes)
+ - help2man (optional, it is needed for building manual pages)
+ 
+diff --git a/configure.ac b/configure.ac
+index 4e22314..d5194b8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,7 @@ AC_SUBST([regular_CFLAGS])
+ # Checks for header files.
+ PKG_CHECK_MODULES([x11], [x11])
+ PKG_CHECK_MODULES([glib], [glib-2.0])
++PKG_CHECK_MODULES([kmod], [libkmod])
+ AS_IF([test "x$with_pidfile" != xno], [
+ 		PKG_CHECK_MODULES([libbsd], [libbsd >= 0.2.0])
+ 		PKG_CHECK_EXISTS([libbsd = 0.2.0], [AC_DEFINE(HAVE_LIBBSD_020)])
+diff --git a/src/bbconfig.c b/src/bbconfig.c
+index 4f5ac7a..62a3306 100644
+--- a/src/bbconfig.c
++++ b/src/bbconfig.c
+@@ -251,12 +251,6 @@ Bumblebee homepage: <http://Bumblebee-Project.org/>\n", out);
+  */
+ static int bbconfig_parse_common(int opt, char *value) {
+   switch (opt) {
+-    case 'q'://quiet mode
+-      bb_status.verbosity = VERB_NONE;
+-      break;
+-    case OPT_DEBUG://debug mode
+-      bb_status.verbosity = VERB_ALL;
+-      break;
+     case 'd'://X display number
+       set_string_value(&bb_config.x_display, value);
+       break;
+@@ -307,6 +301,12 @@ void bbconfig_parse_opts(int argc, char *argv[], int conf_round) {
+             bb_status.verbosity++;
+           }
+           break;
++        case 'q'://quiet mode
++          bb_status.verbosity = VERB_NONE;
++          break;
++        case OPT_DEBUG://debug mode
++          bb_status.verbosity = VERB_ALL;
++          break;
+         case 's': /* Unix socket to use for communication */
+           set_string_value(&bb_config.socket_path, optarg);
+           break;
+diff --git a/src/bbconfig.h b/src/bbconfig.h
+index 656286b..a19f5d3 100644
+--- a/src/bbconfig.h
++++ b/src/bbconfig.h
+@@ -26,6 +26,7 @@
+ #include <unistd.h> //for pid_t
+ #include <limits.h> //for CHAR_MAX
+ #include <glib.h>
++#include <libkmod.h>
+ 
+ /* Daemon states */
+ #define BB_DAEMON 1
+@@ -118,6 +119,7 @@ struct bb_status_struct {
+     int x_pipe[2];//pipes for reading/writing output from X's stdout/stderr
+     gboolean use_syslog;
+     char *program_name;
++    struct kmod_ctx *kmod_ctx;
+ };
+ 
+ /* Structure containing the configuration. */
+diff --git a/src/bblogger.c b/src/bblogger.c
+index ba3787e..7c13c93 100644
+--- a/src/bblogger.c
++++ b/src/bblogger.c
+@@ -228,7 +228,7 @@ void check_xorg_pipe(void){
+         /* line / buffer is full, process the remaining buffer the next round */
+         repeat = 1;
+       }
+-    }else{
++    } else {
+       if (r == 0 || (errno != EAGAIN && r == -1)){
+         /* the pipe is closed/invalid. Clean up. */
+         if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+@@ -257,5 +257,5 @@ void check_xorg_pipe(void){
+         memmove(x_output_buffer, next_part, x_buffer_pos);
+       }
+     }
+-  }while(repeat);
++  }while (repeat);
+ }/* check_xorg_pipe */
+diff --git a/src/bumblebeed.c b/src/bumblebeed.c
+index a911da9..6e0ade5 100644
+--- a/src/bumblebeed.c
++++ b/src/bumblebeed.c
+@@ -34,6 +34,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <getopt.h>
++#include <libkmod.h>
+ #ifdef WITH_PIDFILE
+ #ifdef HAVE_LIBBSD_020
+ #include <libutil.h>
+@@ -488,6 +489,14 @@ int main(int argc, char* argv[]) {
+ 
+   free(pci_id_igd);
+ 
++  // kmod context have to be available for driver detection
++  bb_status.kmod_ctx = kmod_new(NULL, NULL);
++  if (bb_status.kmod_ctx == NULL) {
++    bb_log(LOG_ERR, "kmod_new() failed!\n");
++    bb_closelog();
++    exit(EXIT_FAILURE);
++  }
++
+   GKeyFile *bbcfg = bbconfig_parse_conf();
+   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);
+   driver_detect();
+@@ -500,6 +509,7 @@ int main(int argc, char* argv[]) {
+ 
+   /* dump the config after detecting the driver */
+   config_dump();
++
+   if (config_validate() != 0) {
+     return (EXIT_FAILURE);
+   }
+@@ -572,5 +582,7 @@ int main(int argc, char* argv[]) {
+   //close X pipe, if any parts of it are open still
+   if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+   if (bb_status.x_pipe[1] != -1){close(bb_status.x_pipe[1]); bb_status.x_pipe[1] = -1;}
++  //cleanup kmod context
++  kmod_unref(bb_status.kmod_ctx);
+   return (EXIT_SUCCESS);
+ }
+diff --git a/src/module.c b/src/module.c
+index bb32e15..ef3e84c 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -24,91 +24,152 @@
+ #include <ctype.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <libkmod.h>
++#include <errno.h>
+ #include "module.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
++#include "bbconfig.h"
++
++int module_unload_recursive(struct kmod_module *mod);
+ 
+ /**
+- * Checks in /proc/modules whether a kernel module is loaded
++ * Checks whether a kernel module is loaded
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the module is loaded, 0 otherwise
+  */
+ int module_is_loaded(char *driver) {
+-  // use the same buffer length as lsmod
+-  char buffer[4096];
+-  FILE * bbs = fopen("/proc/modules", "r");
+-  int ret = 0;
+-  /* assume mod_len <= sizeof(buffer) */
+-  int mod_len = strlen(driver);
++  int err, state;
++  struct kmod_module *mod;
+ 
+-  if (bbs == 0) {//error opening, return -1
+-    bb_log(LOG_DEBUG, "Couldn't open /proc/modules");
+-    return -1;
++  err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++      driver, err);
++    return 0;
+   }
+-  while (fgets(buffer, sizeof(buffer), bbs)) {
+-    /* match "module" with "module " and not "module-blah" */
+-    if (!strncmp(buffer, driver, mod_len) && isspace(buffer[mod_len])) {
+-      /* module is found */
+-      ret = 1;
+-      break;
+-    }
+-  }
+-  fclose(bbs);
+-  return ret;
++
++  state = kmod_module_get_initstate(mod);
++  kmod_module_unref(mod);
++
++  return state == KMOD_MODULE_LIVE;
+ }
+ 
+ /**
+- * Attempts to load a module. If the module has not been loaded after ten
+- * seconds, give up
++ * Attempts to load a module.
+  *
+  * @param module_name The filename of the module to be loaded
+  * @param driver The name of the driver to be loaded
+  * @return 1 if the driver is successfully loaded, 0 otherwise
+  */
+ int module_load(char *module_name, char *driver) {
++  int err = 0;
++  int flags = KMOD_PROBE_IGNORE_LOADED;
++  struct kmod_list *l, *list = NULL;
++
+   if (module_is_loaded(driver) == 0) {
+     /* the module has not loaded yet, try to load it */
+-    bb_log(LOG_INFO, "Loading driver %s (module %s)\n", driver, module_name);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      module_name,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    if (module_is_loaded(driver) == 0) {
+-      bb_log(LOG_ERR, "Module %s could not be loaded (timeout?)\n", module_name);
++
++    bb_log(LOG_INFO, "Loading driver '%s' (module '%s')\n", driver, module_name);
++    err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++        module_name, err);
++      return 0;
++    }
++
++    if (list == NULL) {
++      bb_log(LOG_ERR, "Module '%s' not found.\n", module_name);
+       return 0;
+     }
++
++    kmod_list_foreach(l, list) {
++      struct kmod_module *mod = kmod_module_get_module(l);
++
++      bb_log(LOG_DEBUG, "Loading module '%s'.\n", kmod_module_get_name(mod));
++      err = kmod_module_probe_insert_module(mod, flags, NULL, NULL, NULL, 0);
++
++      if (err < 0) {
++        bb_log(LOG_DEBUG, "kmod_module_probe_insert_module(%s) failed (err: %d).\n",
++          kmod_module_get_name(mod), err);
++      }
++
++      kmod_module_unref(mod);
++
++      if (err < 0) {
++        break;
++      }
++    }
++
++    kmod_module_unref_list(list);
++  }
++
++  return err >= 0;
++}
++
++/**
++ * Unloads module and modules that are depending on this module.
++ *
++ * @param mod Reference to libkmod module
++ * @return 1 if the module is successfully unloaded, 0 otherwise
++ */
++int module_unload_recursive(struct kmod_module *mod) {
++  int err = 0, flags = 0, refcnt;
++  struct kmod_list *holders;
++
++  holders = kmod_module_get_holders(mod);
++  if (holders != NULL) {
++    struct kmod_list *itr;
++
++    kmod_list_foreach(itr, holders) {
++      struct kmod_module *hm = kmod_module_get_module(itr);
++      err = module_unload_recursive(hm);
++      kmod_module_unref(hm);
++
++      if (err < 0) {
++        break;
++      }
++    }
++    kmod_module_unref_list(holders);
+   }
+-  return 1;
++
++  refcnt = kmod_module_get_refcnt(mod);
++  if (refcnt == 0) {
++    bb_log(LOG_INFO, "Unloading module %s\n", kmod_module_get_name(mod));
++    err = kmod_module_remove_module(mod, flags);
++  } else {
++    bb_log(LOG_ERR, "Failed to unload module '%s' (ref count: %d).\n",
++      kmod_module_get_name(mod), refcnt);
++    err = 1;
++  }
++
++  return err == 0;
+ }
+ 
+ /**
+- * Attempts to unload a module if loaded, for ten seconds before
+- * giving up
++ * Attempts to unload a module if loaded.
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the driver is successfully unloaded, 0 otherwise
+  */
+ int module_unload(char *driver) {
++  int err;
++  struct kmod_module *mod;
+   if (module_is_loaded(driver) == 1) {
+-    int retries = 30;
+-    bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      "-r",
+-      driver,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    while (retries-- > 0 && module_is_loaded(driver) == 1) {
+-      usleep(100000);
+-    }
+-    if (module_is_loaded(driver) == 1) {
+-      bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
++    err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++        driver, err);
+       return 0;
+     }
++
++    err = module_unload_recursive(mod);
++    kmod_module_unref(mod);
++
++    return err;
+   }
+   return 1;
+ }
+@@ -120,18 +181,20 @@ int module_unload(char *driver) {
+  * @return 1 if the module is available for loading, 0 otherwise
+  */
+ int module_is_available(char *module_name) {
+-  /* HACK to support call from optirun */
+-  char *modprobe_bin = "/sbin/modprobe";
+-  if (access(modprobe_bin, X_OK)) {
+-    /* if /sbin/modprobe is not found, pray that PATH contains it */
+-    modprobe_bin = "modprobe";
++  int err, available;
++  struct kmod_list *list = NULL;
++
++  err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++      module_name, err);
++    return 0;
+   }
+-  char *mod_argv[] = {
+-    modprobe_bin,
+-    "--dry-run",
+-    "--quiet",
+-    module_name,
+-    NULL
+-  };
+-  return bb_run_fork(mod_argv, 1) == EXIT_SUCCESS;
++
++  available = list != NULL;
++
++  kmod_module_unref_list(list);
++
++  return available;
+ }
+diff --git a/src/optirun.c b/src/optirun.c
+index bcc6c13..f05f05c 100644
+--- a/src/optirun.c
++++ b/src/optirun.c
+@@ -37,7 +37,6 @@
+ #include "bbsocketclient.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
+-#include "driver.h"
+ 
+ 
+ /**

--- a/wily/bumblebee/debian/patches/series
+++ b/wily/bumblebee/debian/patches/series
@@ -5,3 +5,4 @@ fix-typos.patch
 xorg-binary-config.patch
 ignore-systemd-logind-noise.patch
 ignore-failure-to-set-DRM-interface.patch
+libkmod.patch

--- a/wily/bumblebee/debian/rules
+++ b/wily/bumblebee/debian/rules
@@ -48,13 +48,6 @@ override_dh_install:
 	   debian/bumblebee/usr/share/bash-completion/completions/
 	rm -rf debian/bumblebee/etc/bash_completion.d/
 
-ifeq ($(VENDOR),Ubuntu)
-	# On Ubuntu modprobe remove line is not present, which breaks module
-	# unloading; https://github.com/Bumblebee-Project/Bumblebee/issues/681
-	echo "# Workaround to make sure nvidia-uvm is removed as well" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-	echo "remove nvidia rmmod nvidia-uvm nvidia" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-endif
-
 override_dh_installinit:
 	dh_installinit --name=bumblebeed
 

--- a/xenial/bumblebee/debian/changelog
+++ b/xenial/bumblebee/debian/changelog
@@ -1,3 +1,11 @@
+bumblebee (3.2.1-96~xenialppa1) UNRELEASED; urgency=medium
+
+  * Backport libkmod.patch from upstream develop branch and add build-dep
+    on libkmod-dev. Definitively fixes all issues with multiple kernel
+    modules loading/unloading.
+
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:45 +0100
+
 bumblebee (3.2.1-95~xenialppa1) xenial; urgency=medium
 
   * Set Ubuntu default kernel driver to nvidia

--- a/xenial/bumblebee/debian/changelog
+++ b/xenial/bumblebee/debian/changelog
@@ -3,6 +3,7 @@ bumblebee (3.2.1-96~xenialppa1) UNRELEASED; urgency=medium
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
+  * Remove Ubuntu modprobe hack from debian/rules
 
  -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:45 +0100
 

--- a/xenial/bumblebee/debian/changelog
+++ b/xenial/bumblebee/debian/changelog
@@ -1,11 +1,11 @@
-bumblebee (3.2.1-96~xenialppa1) UNRELEASED; urgency=medium
+bumblebee (3.2.1-96~xenialppa1) xenial; urgency=medium
 
   * Backport libkmod.patch from upstream develop branch and add build-dep
     on libkmod-dev. Definitively fixes all issues with multiple kernel
     modules loading/unloading.
   * Remove Ubuntu modprobe hack from debian/rules
 
- -- Luca Boccassi <luca.boccassi@gmail.com>  Thu, 19 May 2016 19:26:45 +0100
+ -- Luca Boccassi <luca.boccassi@gmail.com>  Fri, 20 May 2016 01:40:28 +0100
 
 bumblebee (3.2.1-95~xenialppa1) xenial; urgency=medium
 

--- a/xenial/bumblebee/debian/control
+++ b/xenial/bumblebee/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  libglib2.0-dev,
  libx11-dev,
  pkg-config,
+ libkmod-dev,
 Standards-Version: 3.9.5
 Homepage: https://launchpad.net/~bumblebee
 Vcs-Browser: https://github.com/Bumblebee-Project/Bumblebee

--- a/xenial/bumblebee/debian/patches/libkmod.patch
+++ b/xenial/bumblebee/debian/patches/libkmod.patch
@@ -1,0 +1,434 @@
+From: =?utf-8?q?Ond=C5=99ej_Jano=C5=A1=C3=ADk?= <j.ondra14@gmail.com>
+Date: Thu, 5 May 2016 18:48:43 +0200
+Subject: module: use libkmod2 instead of modprobe
+
+---
+ Makefile.am      |   8 +--
+ README.markdown  |   1 +
+ configure.ac     |   1 +
+ src/bbconfig.c   |  12 ++--
+ src/bbconfig.h   |   2 +
+ src/bblogger.c   |   4 +-
+ src/bumblebeed.c |  12 ++++
+ src/module.c     | 185 +++++++++++++++++++++++++++++++++++++------------------
+ src/optirun.c    |   1 -
+ 9 files changed, 152 insertions(+), 74 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0f38a54..25e32d5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -10,7 +10,7 @@ AM_CPPFLAGS = ${regular_CPPFLAGS} \
+ 		-DCONF_XORG='"$(bumblebeedconfdir)/xorg.conf.DRIVER"' \
+ 		-DCONF_XORG_DIR='"$(bumblebeedconfdir)/xorg.conf.d"'
+ AM_CFLAGS = ${regular_CFLAGS} \
+-		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} \
++		${x11_CFLAGS} ${libbsd_CFLAGS} ${glib_CFLAGS} ${kmod_CFLAGS} \
+ 		-Wextra -funsigned-char -DGITVERSION='"${GITVERSION}"'
+ 
+ noinst_SCRIPTS = scripts/systemd/bumblebeed.service \
+@@ -49,13 +49,13 @@ sbin_PROGRAMS = bin/bumblebeed
+ bin_PROGRAMS = bin/optirun
+ 
+ bin_optirun_SOURCES = src/module.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+-	src/bbsocket.c src/driver.c src/optirun.c src/bbsocketclient.c
+-bin_optirun_LDADD = ${glib_LIBS} -lrt
++	src/bbsocket.c src/optirun.c src/bbsocketclient.c
++bin_optirun_LDADD = ${glib_LIBS} ${kmod_LIBS} -lrt
+ bin_bumblebeed_SOURCES = src/pci.c src/bbconfig.c src/bblogger.c src/bbrun.c \
+ 	src/bbsocket.c src/module.c src/bbsecondary.c src/switch/switching.c \
+ 	src/switch/sw_bbswitch.c src/switch/sw_switcheroo.c \
+ 	src/driver.c src/bumblebeed.c
+-bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} -lrt
++bin_bumblebeed_LDADD = ${x11_LIBS} ${libbsd_LIBS} ${glib_LIBS} ${kmod_LIBS} -lrt
+ 
+ dist_doc_DATA = $(relnotes) README.markdown
+ bumblebeedconf_DATA = conf/bumblebee.conf conf/xorg.conf.nouveau conf/xorg.conf.nvidia
+diff --git a/README.markdown b/README.markdown
+index b534a6c..5c2baa5 100644
+--- a/README.markdown
++++ b/README.markdown
+@@ -19,6 +19,7 @@ The following packages are dependencies for the build process:
+ - pkg-config
+ - glib-2.0 and development headers
+ - libx11 and development headers
++- libkmod2 and development headers
+ - libbsd and development headers (if pidfile support is enabled, default yes)
+ - help2man (optional, it is needed for building manual pages)
+ 
+diff --git a/configure.ac b/configure.ac
+index 4e22314..d5194b8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -132,6 +132,7 @@ AC_SUBST([regular_CFLAGS])
+ # Checks for header files.
+ PKG_CHECK_MODULES([x11], [x11])
+ PKG_CHECK_MODULES([glib], [glib-2.0])
++PKG_CHECK_MODULES([kmod], [libkmod])
+ AS_IF([test "x$with_pidfile" != xno], [
+ 		PKG_CHECK_MODULES([libbsd], [libbsd >= 0.2.0])
+ 		PKG_CHECK_EXISTS([libbsd = 0.2.0], [AC_DEFINE(HAVE_LIBBSD_020)])
+diff --git a/src/bbconfig.c b/src/bbconfig.c
+index 4f5ac7a..62a3306 100644
+--- a/src/bbconfig.c
++++ b/src/bbconfig.c
+@@ -251,12 +251,6 @@ Bumblebee homepage: <http://Bumblebee-Project.org/>\n", out);
+  */
+ static int bbconfig_parse_common(int opt, char *value) {
+   switch (opt) {
+-    case 'q'://quiet mode
+-      bb_status.verbosity = VERB_NONE;
+-      break;
+-    case OPT_DEBUG://debug mode
+-      bb_status.verbosity = VERB_ALL;
+-      break;
+     case 'd'://X display number
+       set_string_value(&bb_config.x_display, value);
+       break;
+@@ -307,6 +301,12 @@ void bbconfig_parse_opts(int argc, char *argv[], int conf_round) {
+             bb_status.verbosity++;
+           }
+           break;
++        case 'q'://quiet mode
++          bb_status.verbosity = VERB_NONE;
++          break;
++        case OPT_DEBUG://debug mode
++          bb_status.verbosity = VERB_ALL;
++          break;
+         case 's': /* Unix socket to use for communication */
+           set_string_value(&bb_config.socket_path, optarg);
+           break;
+diff --git a/src/bbconfig.h b/src/bbconfig.h
+index 656286b..a19f5d3 100644
+--- a/src/bbconfig.h
++++ b/src/bbconfig.h
+@@ -26,6 +26,7 @@
+ #include <unistd.h> //for pid_t
+ #include <limits.h> //for CHAR_MAX
+ #include <glib.h>
++#include <libkmod.h>
+ 
+ /* Daemon states */
+ #define BB_DAEMON 1
+@@ -118,6 +119,7 @@ struct bb_status_struct {
+     int x_pipe[2];//pipes for reading/writing output from X's stdout/stderr
+     gboolean use_syslog;
+     char *program_name;
++    struct kmod_ctx *kmod_ctx;
+ };
+ 
+ /* Structure containing the configuration. */
+diff --git a/src/bblogger.c b/src/bblogger.c
+index ba3787e..7c13c93 100644
+--- a/src/bblogger.c
++++ b/src/bblogger.c
+@@ -228,7 +228,7 @@ void check_xorg_pipe(void){
+         /* line / buffer is full, process the remaining buffer the next round */
+         repeat = 1;
+       }
+-    }else{
++    } else {
+       if (r == 0 || (errno != EAGAIN && r == -1)){
+         /* the pipe is closed/invalid. Clean up. */
+         if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+@@ -257,5 +257,5 @@ void check_xorg_pipe(void){
+         memmove(x_output_buffer, next_part, x_buffer_pos);
+       }
+     }
+-  }while(repeat);
++  }while (repeat);
+ }/* check_xorg_pipe */
+diff --git a/src/bumblebeed.c b/src/bumblebeed.c
+index a911da9..6e0ade5 100644
+--- a/src/bumblebeed.c
++++ b/src/bumblebeed.c
+@@ -34,6 +34,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <getopt.h>
++#include <libkmod.h>
+ #ifdef WITH_PIDFILE
+ #ifdef HAVE_LIBBSD_020
+ #include <libutil.h>
+@@ -488,6 +489,14 @@ int main(int argc, char* argv[]) {
+ 
+   free(pci_id_igd);
+ 
++  // kmod context have to be available for driver detection
++  bb_status.kmod_ctx = kmod_new(NULL, NULL);
++  if (bb_status.kmod_ctx == NULL) {
++    bb_log(LOG_ERR, "kmod_new() failed!\n");
++    bb_closelog();
++    exit(EXIT_FAILURE);
++  }
++
+   GKeyFile *bbcfg = bbconfig_parse_conf();
+   bbconfig_parse_opts(argc, argv, PARSE_STAGE_DRIVER);
+   driver_detect();
+@@ -500,6 +509,7 @@ int main(int argc, char* argv[]) {
+ 
+   /* dump the config after detecting the driver */
+   config_dump();
++
+   if (config_validate() != 0) {
+     return (EXIT_FAILURE);
+   }
+@@ -572,5 +582,7 @@ int main(int argc, char* argv[]) {
+   //close X pipe, if any parts of it are open still
+   if (bb_status.x_pipe[0] != -1){close(bb_status.x_pipe[0]); bb_status.x_pipe[0] = -1;}
+   if (bb_status.x_pipe[1] != -1){close(bb_status.x_pipe[1]); bb_status.x_pipe[1] = -1;}
++  //cleanup kmod context
++  kmod_unref(bb_status.kmod_ctx);
+   return (EXIT_SUCCESS);
+ }
+diff --git a/src/module.c b/src/module.c
+index bb32e15..ef3e84c 100644
+--- a/src/module.c
++++ b/src/module.c
+@@ -24,91 +24,152 @@
+ #include <ctype.h>
+ #include <stdlib.h>
+ #include <unistd.h>
++#include <libkmod.h>
++#include <errno.h>
+ #include "module.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
++#include "bbconfig.h"
++
++int module_unload_recursive(struct kmod_module *mod);
+ 
+ /**
+- * Checks in /proc/modules whether a kernel module is loaded
++ * Checks whether a kernel module is loaded
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the module is loaded, 0 otherwise
+  */
+ int module_is_loaded(char *driver) {
+-  // use the same buffer length as lsmod
+-  char buffer[4096];
+-  FILE * bbs = fopen("/proc/modules", "r");
+-  int ret = 0;
+-  /* assume mod_len <= sizeof(buffer) */
+-  int mod_len = strlen(driver);
++  int err, state;
++  struct kmod_module *mod;
+ 
+-  if (bbs == 0) {//error opening, return -1
+-    bb_log(LOG_DEBUG, "Couldn't open /proc/modules");
+-    return -1;
++  err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++      driver, err);
++    return 0;
+   }
+-  while (fgets(buffer, sizeof(buffer), bbs)) {
+-    /* match "module" with "module " and not "module-blah" */
+-    if (!strncmp(buffer, driver, mod_len) && isspace(buffer[mod_len])) {
+-      /* module is found */
+-      ret = 1;
+-      break;
+-    }
+-  }
+-  fclose(bbs);
+-  return ret;
++
++  state = kmod_module_get_initstate(mod);
++  kmod_module_unref(mod);
++
++  return state == KMOD_MODULE_LIVE;
+ }
+ 
+ /**
+- * Attempts to load a module. If the module has not been loaded after ten
+- * seconds, give up
++ * Attempts to load a module.
+  *
+  * @param module_name The filename of the module to be loaded
+  * @param driver The name of the driver to be loaded
+  * @return 1 if the driver is successfully loaded, 0 otherwise
+  */
+ int module_load(char *module_name, char *driver) {
++  int err = 0;
++  int flags = KMOD_PROBE_IGNORE_LOADED;
++  struct kmod_list *l, *list = NULL;
++
+   if (module_is_loaded(driver) == 0) {
+     /* the module has not loaded yet, try to load it */
+-    bb_log(LOG_INFO, "Loading driver %s (module %s)\n", driver, module_name);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      module_name,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    if (module_is_loaded(driver) == 0) {
+-      bb_log(LOG_ERR, "Module %s could not be loaded (timeout?)\n", module_name);
++
++    bb_log(LOG_INFO, "Loading driver '%s' (module '%s')\n", driver, module_name);
++    err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++        module_name, err);
++      return 0;
++    }
++
++    if (list == NULL) {
++      bb_log(LOG_ERR, "Module '%s' not found.\n", module_name);
+       return 0;
+     }
++
++    kmod_list_foreach(l, list) {
++      struct kmod_module *mod = kmod_module_get_module(l);
++
++      bb_log(LOG_DEBUG, "Loading module '%s'.\n", kmod_module_get_name(mod));
++      err = kmod_module_probe_insert_module(mod, flags, NULL, NULL, NULL, 0);
++
++      if (err < 0) {
++        bb_log(LOG_DEBUG, "kmod_module_probe_insert_module(%s) failed (err: %d).\n",
++          kmod_module_get_name(mod), err);
++      }
++
++      kmod_module_unref(mod);
++
++      if (err < 0) {
++        break;
++      }
++    }
++
++    kmod_module_unref_list(list);
++  }
++
++  return err >= 0;
++}
++
++/**
++ * Unloads module and modules that are depending on this module.
++ *
++ * @param mod Reference to libkmod module
++ * @return 1 if the module is successfully unloaded, 0 otherwise
++ */
++int module_unload_recursive(struct kmod_module *mod) {
++  int err = 0, flags = 0, refcnt;
++  struct kmod_list *holders;
++
++  holders = kmod_module_get_holders(mod);
++  if (holders != NULL) {
++    struct kmod_list *itr;
++
++    kmod_list_foreach(itr, holders) {
++      struct kmod_module *hm = kmod_module_get_module(itr);
++      err = module_unload_recursive(hm);
++      kmod_module_unref(hm);
++
++      if (err < 0) {
++        break;
++      }
++    }
++    kmod_module_unref_list(holders);
+   }
+-  return 1;
++
++  refcnt = kmod_module_get_refcnt(mod);
++  if (refcnt == 0) {
++    bb_log(LOG_INFO, "Unloading module %s\n", kmod_module_get_name(mod));
++    err = kmod_module_remove_module(mod, flags);
++  } else {
++    bb_log(LOG_ERR, "Failed to unload module '%s' (ref count: %d).\n",
++      kmod_module_get_name(mod), refcnt);
++    err = 1;
++  }
++
++  return err == 0;
+ }
+ 
+ /**
+- * Attempts to unload a module if loaded, for ten seconds before
+- * giving up
++ * Attempts to unload a module if loaded.
+  *
+  * @param driver The name of the driver (not a filename)
+  * @return 1 if the driver is successfully unloaded, 0 otherwise
+  */
+ int module_unload(char *driver) {
++  int err;
++  struct kmod_module *mod;
+   if (module_is_loaded(driver) == 1) {
+-    int retries = 30;
+-    bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+-    char *mod_argv[] = {
+-      "modprobe",
+-      "-r",
+-      driver,
+-      NULL
+-    };
+-    bb_run_fork_wait(mod_argv, 10);
+-    while (retries-- > 0 && module_is_loaded(driver) == 1) {
+-      usleep(100000);
+-    }
+-    if (module_is_loaded(driver) == 1) {
+-      bb_log(LOG_ERR, "Unloading %s driver timed out.\n", driver);
++    err = kmod_module_new_from_name(bb_status.kmod_ctx, driver, &mod);
++
++    if (err < 0) {
++      bb_log(LOG_DEBUG, "kmod_module_new_from_name(%s) failed (err: %d).\n",
++        driver, err);
+       return 0;
+     }
++
++    err = module_unload_recursive(mod);
++    kmod_module_unref(mod);
++
++    return err;
+   }
+   return 1;
+ }
+@@ -120,18 +181,20 @@ int module_unload(char *driver) {
+  * @return 1 if the module is available for loading, 0 otherwise
+  */
+ int module_is_available(char *module_name) {
+-  /* HACK to support call from optirun */
+-  char *modprobe_bin = "/sbin/modprobe";
+-  if (access(modprobe_bin, X_OK)) {
+-    /* if /sbin/modprobe is not found, pray that PATH contains it */
+-    modprobe_bin = "modprobe";
++  int err, available;
++  struct kmod_list *list = NULL;
++
++  err = kmod_module_new_from_lookup(bb_status.kmod_ctx, module_name, &list);
++
++  if (err < 0) {
++    bb_log(LOG_DEBUG, "kmod_module_new_from_lookup(%s) failed (err: %d).\n",
++      module_name, err);
++    return 0;
+   }
+-  char *mod_argv[] = {
+-    modprobe_bin,
+-    "--dry-run",
+-    "--quiet",
+-    module_name,
+-    NULL
+-  };
+-  return bb_run_fork(mod_argv, 1) == EXIT_SUCCESS;
++
++  available = list != NULL;
++
++  kmod_module_unref_list(list);
++
++  return available;
+ }
+diff --git a/src/optirun.c b/src/optirun.c
+index bcc6c13..f05f05c 100644
+--- a/src/optirun.c
++++ b/src/optirun.c
+@@ -37,7 +37,6 @@
+ #include "bbsocketclient.h"
+ #include "bblogger.h"
+ #include "bbrun.h"
+-#include "driver.h"
+ 
+ 
+ /**

--- a/xenial/bumblebee/debian/patches/series
+++ b/xenial/bumblebee/debian/patches/series
@@ -5,3 +5,4 @@ fix-typos.patch
 xorg-binary-config.patch
 ignore-systemd-logind-noise.patch
 ignore-failure-to-set-DRM-interface.patch
+libkmod.patch

--- a/xenial/bumblebee/debian/rules
+++ b/xenial/bumblebee/debian/rules
@@ -50,13 +50,6 @@ override_dh_install:
 	   debian/bumblebee/usr/share/bash-completion/completions/
 	rm -rf debian/bumblebee/etc/bash_completion.d/
 
-ifeq ($(VENDOR),Ubuntu)
-	# On Ubuntu modprobe remove line is not present, which breaks module
-	# unloading; https://github.com/Bumblebee-Project/Bumblebee/issues/681
-	echo "# Workaround to make sure nvidia-uvm is removed as well" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-	echo "remove nvidia rmmod nvidia-uvm nvidia" >> debian/bumblebee/usr/share/bumblebee/modprobe.d/bumblebee.conf
-endif
-
 override_dh_installinit:
 	dh_installinit --name=bumblebeed
 


### PR DESCRIPTION
Note that I have tested this patch only on Debian, I will test it on Ubuntu later tonight, and if it works it can be merged.
Also, there is no libkmod-dev in precise, so I haven't backported it there. Also the drivers there are quite old, so it should be less an issue.
I guess we could try to backport libkmod itself and made it available in the PPA as a dependency if needed.

Fixes #35 https://github.com/Bumblebee-Project/Bumblebee/issues/761