### PR TITLE
Blacklist kernel modules, that are used when installing from nVidia website.

### DIFF
--- a/bionic/bumblebee/debian/bumblebee.conf
+++ b/bionic/bumblebee/debian/bumblebee.conf
@@ -16,6 +16,9 @@ blacklist nvidia-legacy-390xx
 blacklist nvidia
 blacklist nvidia-current
 blacklist nvidia-current-updates
+blacklist nvidia_drm
+blacklist nvidia_uvm
+blacklist nvidia_modeset
 # 304
 blacklist nvidia-304
 blacklist nvidia-304-updates

--- a/bionic/bumblebee/debian/changelog
+++ b/bionic/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1+git20181231-103~bionicppa1) bionic; urgency=low
+  
+  * Blacklist kernel modules, that are used when installing from nVidia website.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 09:21:54 +0200
+
 bumblebee (3.2.1+git20181231-102~bionicppa1) bionic; urgency=low
 
   * Add support for 390xx series on Debian.

--- a/precise/bumblebee/debian/bumblebee.conf
+++ b/precise/bumblebee/debian/bumblebee.conf
@@ -16,6 +16,9 @@ blacklist nvidia-legacy-390xx
 blacklist nvidia
 blacklist nvidia-current
 blacklist nvidia-current-updates
+blacklist nvidia_drm
+blacklist nvidia_uvm
+blacklist nvidia_modeset
 # 304
 blacklist nvidia-304
 blacklist nvidia-304-updates

--- a/precise/bumblebee/debian/changelog
+++ b/precise/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-102~preciseppa1) precise; urgency=low
+  
+  * Blacklist kernel modules, that are used when installing from nVidia website.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 09:21:54 +0200
+
 bumblebee (3.2.1-101~preciseppa1) precise; urgency=low
 
   * Add support for 370, 390 and 396 series.

--- a/trusty/bumblebee/debian/bumblebee.conf
+++ b/trusty/bumblebee/debian/bumblebee.conf
@@ -16,6 +16,9 @@ blacklist nvidia-legacy-390xx
 blacklist nvidia
 blacklist nvidia-current
 blacklist nvidia-current-updates
+blacklist nvidia_drm
+blacklist nvidia_uvm
+blacklist nvidia_modeset
 # 304
 blacklist nvidia-304
 blacklist nvidia-304-updates

--- a/trusty/bumblebee/debian/changelog
+++ b/trusty/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1+git20181231-103~trustyppa1) trusty; urgency=low
+  
+  * Blacklist kernel modules, that are used when installing from nVidia website.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 09:21:54 +0200
+
 bumblebee (3.2.1+git20181231-102~trustyppa1) trusty; urgency=low
 
   * Add support for 390xx series on Debian.

--- a/vivid/bumblebee/debian/bumblebee.conf
+++ b/vivid/bumblebee/debian/bumblebee.conf
@@ -16,6 +16,9 @@ blacklist nvidia-legacy-390xx
 blacklist nvidia
 blacklist nvidia-current
 blacklist nvidia-current-updates
+blacklist nvidia_drm
+blacklist nvidia_uvm
+blacklist nvidia_modeset
 # 304
 blacklist nvidia-304
 blacklist nvidia-304-updates

--- a/vivid/bumblebee/debian/changelog
+++ b/vivid/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-102~vividppa1) vivid; urgency=low
+  
+  * Blacklist kernel modules, that are used when installing from nVidia website.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 09:21:54 +0200
+
 bumblebee (3.2.1-101~vividppa1) vivid; urgency=low
 
   * Add support for 370, 390 and 396 series.

--- a/wily/bumblebee/debian/bumblebee.conf
+++ b/wily/bumblebee/debian/bumblebee.conf
@@ -16,6 +16,9 @@ blacklist nvidia-legacy-390xx
 blacklist nvidia
 blacklist nvidia-current
 blacklist nvidia-current-updates
+blacklist nvidia_drm
+blacklist nvidia_uvm
+blacklist nvidia_modeset
 # 304
 blacklist nvidia-304
 blacklist nvidia-304-updates

--- a/wily/bumblebee/debian/changelog
+++ b/wily/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1-102~wilyppa1) wily; urgency=low
+  
+  * Blacklist kernel modules, that are used when installing from nVidia website.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 09:21:54 +0200
+
 bumblebee (3.2.1-101~wilyppa1) wily; urgency=low
 
   * Add support for 370, 390 and 396 series.

--- a/xenial/bumblebee/debian/bumblebee.conf
+++ b/xenial/bumblebee/debian/bumblebee.conf
@@ -16,6 +16,9 @@ blacklist nvidia-legacy-390xx
 blacklist nvidia
 blacklist nvidia-current
 blacklist nvidia-current-updates
+blacklist nvidia_drm
+blacklist nvidia_uvm
+blacklist nvidia_modeset
 # 304
 blacklist nvidia-304
 blacklist nvidia-304-updates

--- a/xenial/bumblebee/debian/changelog
+++ b/xenial/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1+git20181231-103~xenialppa1) xenial; urgency=low
+  
+  * Blacklist kernel modules, that are used when installing from nVidia website.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 09:21:54 +0200
+
 bumblebee (3.2.1+git20181231-102~xenialppa1) xenial; urgency=low
 
   * Add support for 390xx series on Debian.


### PR DESCRIPTION
Hello @bluca 
this PR blacklists kernel modules, that are used when installing from nVidia website.

This occurs for example with their CUDA repository Ubuntu.
deb http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 /

Thanks, Georgy