### PR TITLE
Add support for Ubuntu 18.04 LTS Enablement Stack.

### DIFF
--- a/bionic/bumblebee/debian/changelog
+++ b/bionic/bumblebee/debian/changelog
@@ -1,3 +1,9 @@
+bumblebee (3.2.1+git20181231-104~bionicppa1) bionic; urgency=low
+  
+  * Add support for Ubuntu 18.04 LTS Enablement Stack.
+
+ -- Georgy Berdyshev <georgyberdyshev@users.noreply.github.com>  Fri, 01 Feb 2019 11:37:29 +0200
+
 bumblebee (3.2.1+git20181231-102~bionicppa1) bionic; urgency=low
 
   * Add support for 390xx series on Debian.

--- a/bionic/bumblebee/debian/control
+++ b/bionic/bumblebee/debian/control
@@ -28,7 +28,7 @@ Pre-Depends:
  dpkg (>= 1.15.7.2),
 Depends:
  bbswitch-dkms | bbswitch-source,
- xserver-xorg-core (>= 2:1.18) | xserver-xorg-core-hwe-16.04 (>= 2:1.18),
+ xserver-xorg-core (>= 2:1.18) | xserver-xorg-core-hwe-18.04 (>= 2:1.20),
  ${misc:Depends},
  ${shlibs:Depends},
 Recommends:


### PR DESCRIPTION
Hello @bluca,

this PR adds support for Ubuntu 18.04 LTS Enablement Stack that contains an updated xserver dependency.

Thanks, Georgy